### PR TITLE
Corrections des liens vers les PDFs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,6 +43,8 @@ jobs:
       run: npm ci
     - name: Generate ⚙️
       run: npm run generate
+    - name: Create .nojekyll file 🧪
+      run: touch ./dist/.nojekyll
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/components/Cards/LatexContentCard.vue
+++ b/components/Cards/LatexContentCard.vue
@@ -6,6 +6,8 @@ defineProps<{
   linkPrefix: string
   object: LatexContentObject
 }>()
+
+const config = useRuntimeConfig()
 </script>
 
 <template>
@@ -23,7 +25,7 @@ defineProps<{
         <icon name="bi:box-arrow-in-right" /> {{ btnCheck }}
       </b-button>
       <b-button
-        :href="`/pdf/${linkPrefix}/${object.slug}.pdf`"
+        :href="`/${config.public.baseUrl}/pdf/${linkPrefix}/${object.slug}.pdf`"
         download="true"
         variant="secondary"
       >

--- a/content/latex/lecons/170.tex
+++ b/content/latex/lecons/170.tex
@@ -1,5 +1,4 @@
 \input{../common}
-\input{../bibliography}
 
 \begin{document}
   %<*content>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,8 @@ import eslintPlugin from '@nabla/vite-plugin-eslint'
 import 'dotenv/config'
 import { siteMeta } from './site/meta'
 
+const baseUrl = 'SenCoursDeMaths'
+
 export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
@@ -21,7 +23,7 @@ export default defineNuxtConfig({
 
   ssr: true,
   app: {
-    baseURL: '/SenCoursDeMaths/',
+    baseURL: `/${baseUrl}/`,
     head: {
       titleTemplate: `%s | ${siteMeta.title}`,
       htmlAttrs: {
@@ -46,6 +48,12 @@ export default defineNuxtConfig({
     url: siteMeta.url,
     name: siteMeta.title,
     trailingSlash: true,
+  },
+
+  runtimeConfig: {
+    public: {
+      baseUrl,
+    },
   },
 
   experimental: {
@@ -111,6 +119,7 @@ export default defineNuxtConfig({
     skipInspections: [
       'link-text',
       'no-uppercase-chars',
+      'redirects',
     ],
   },
 

--- a/pages/developpements/[slug].vue
+++ b/pages/developpements/[slug].vue
@@ -6,7 +6,8 @@ const route = useRoute()
 const { data: development, status, error } = await useFetch<DevelopmentContent>(`/_api/latex/developpements/${route.params.slug}.json`)
 
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 useCaveatsBanner(`https://github.com/${siteMeta.github.username}/${siteMeta.github.repository}/edit/main/content/latex${path}.tex`)
 
 usePageHead({ title: 'Affichage d\'un développement' })

--- a/pages/developpements/index.vue
+++ b/pages/developpements/index.vue
@@ -6,7 +6,8 @@ const { data: developments, status, error } = await useFetch<Development[]>('/_a
 
 const route = useRoute()
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 
 usePageHead({ title: 'Liste des développements' })
 </script>

--- a/pages/fiches/[slug].vue
+++ b/pages/fiches/[slug].vue
@@ -6,7 +6,8 @@ const route = useRoute()
 const { data: sheet, status, error } = await useFetch<SheetContent>(`/_api/latex/fiches/${route.params.slug}.json`)
 
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 useCaveatsBanner(`https://github.com/${siteMeta.github.username}/${siteMeta.github.repository}/edit/main/content/latex${path}.tex`)
 
 usePageHead({ title: 'Affichage d\'une fiche' })

--- a/pages/fiches/index.vue
+++ b/pages/fiches/index.vue
@@ -6,7 +6,8 @@ const { data: sheets, status, error } = await useFetch<Sheet[]>('/_api/latex/fic
 
 const route = useRoute()
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 
 usePageHead({ title: 'Liste des fiches' })
 </script>

--- a/pages/historique/[slug].vue
+++ b/pages/historique/[slug].vue
@@ -6,7 +6,8 @@ const route = useRoute()
 const { data: ranking, status, error } = await useFetch<RankingContent>(`/_api/latex/historique/${route.params.slug}.json`)
 
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 useCaveatsBanner(`https://github.com/${siteMeta.github.username}/${siteMeta.github.repository}/edit/main/content/latex${path}.tex`)
 
 usePageHead({ title: 'Affichage d\'un classement' })

--- a/pages/historique/index.vue
+++ b/pages/historique/index.vue
@@ -6,7 +6,8 @@ const { data: rankings, status, error } = await useFetch<Ranking[]>('/_api/latex
 
 const route = useRoute()
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 
 usePageHead({ title: 'Historique des admissions' })
 

--- a/pages/lecons/[slug].vue
+++ b/pages/lecons/[slug].vue
@@ -6,7 +6,8 @@ const route = useRoute()
 const { data: lesson, status, error } = await useFetch<LessonContent>(`/_api/latex/lecons/${route.params.slug}.json`)
 
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 useCaveatsBanner(`https://github.com/${siteMeta.github.username}/${siteMeta.github.repository}/edit/main/content/latex${path}.tex`)
 
 usePageHead({ title: 'Affichage d\'une leçon' })

--- a/pages/lecons/index.vue
+++ b/pages/lecons/index.vue
@@ -6,7 +6,8 @@ const { data: lessons, status, error } = await useFetch<Lesson[]>('/_api/latex/l
 
 const route = useRoute()
 const path = removeTrailingSlashIfPossible(route.path)
-usePdfBanner(`/pdf${path}.pdf`)
+const config = useRuntimeConfig()
+usePdfBanner(`/${config.public.baseUrl}/pdf${path}.pdf`)
 
 usePageHead({ title: 'Liste des leçons' })
 </script>

--- a/site/meta.ts
+++ b/site/meta.ts
@@ -44,7 +44,7 @@ interface SiteMeta {
 export const siteMeta: SiteMeta = {
   title: 'SenCoursDeMaths',
   description: 'Petit site contenant une flopée de ressources  de mathématiques pour le lycée : plans, exercices,évaluations, ...',
-  url: 'https://imbodj.github.io/SenCoursDeMaths',
+  url: 'https://imbodj.github.io/SenCoursDeMaths/',
   github: {
     username: 'imbodj',
     repository: 'SenCoursDeMaths',


### PR DESCRIPTION
Cette pull request permet de :

* corriger la plupart des liens vers les PDFs (un lien absolu était utilisé, il faut ajouter le préfix `/SenCoursDeMaths/` devant) ;
* créer un fichier `.nojekyll` dans le répertoire _dist_ afin que Jekyll ne s'exécute pas (ce qui pouvait paralyser Nuxt).